### PR TITLE
Adding more machine metrics to Node-Exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,16 @@ services:
       - back-tier
   
   node-exporter:
+    container_name: node-exporter
     image: prom/node-exporter
+    volumes: 
+      - /proc:/host/proc
+      - /sys:/host/sys
+      - /:/rootfs
+    command:
+      - '-collector.procfs=/host/proc'
+      - '-collector.sysfs=/host/sysfs'
+      - '-collector.filesystem.ignored-mount-points="^/(sys|proc|dev|host|etc)($$|/)"'
     expose:
       - 9100
     networks:


### PR DESCRIPTION
- Allows the collection of metrics from the host system, rather than just the node-exporter container. See [prometheus/node-exporter](https://github.com/prometheus/node_exporter#using-docker) for more details!
