### PR TITLE
Add double dash to flags in alertmanager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,8 +64,8 @@ services:
       - back-tier
     restart: always
     command:
-      - '-config.file=/etc/alertmanager/config.yml'
-      - '-storage.path=/alertmanager'
+      - '--config.file=/etc/alertmanager/config.yml'
+      - '--storage.path=/alertmanager'
     deploy:
       placement:
         constraints:


### PR DESCRIPTION
According to [this official post](https://prometheus.io/blog/2017/06/21/prometheus-20-alpha3-new-rule-format/) flags now  require double dash instead single ones