### PR TITLE
Use raw images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 Here's a quick start using Play-With-Docker (PWD) to start-up a [Prometheus](http://prometheus.io/) stack containing Prometheus, Grafana and Node scraper to monitor your Docker infrastructure. The Try in PWD below allows you to quickly deploy the entire Prometheus stack with a click of the button. This will allow you to quickly test the stack to see if it meets your needs.
 
-[![Try in PWD](https://github.com/play-with-docker/stacks/raw/master/assets/images/button.png)](https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/vegasbrianc/prometheus/version-2/pwd-stack.yml) 
+[![Try in PWD](https://github.com/play-with-docker/stacks/raw/master/assets/images/button.png)](https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/vegasbrianc/prometheus/version-2/pwd-stack.yml)
 
 # Pre-requisites
 Before we get started installing the Prometheus stack. Ensure you install the latest version of docker and [docker swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/) on your Docker host machine. Docker Swarm is installed automatically when using Docker for Mac or Docker for Windows.
 
 # Installation & Configuration
-Clone the project locally to your Docker host. 
+Clone the project locally to your Docker host.
 
 If you would like to change which targets should be monitored or make configuration changes edit the [/prometheus/prometheus.yml](https://github.com/vegasbrianc/prometheus/blob/version-2/prometheus/prometheus.yml) file. The targets section is where you define what should be monitored by Prometheus. The names defined in this file are actually sourced from the service name in the docker-compose file. If you wish to change names of the services you can add the "container_name" parameter in the `docker-compose.yml` file.
 
@@ -43,7 +43,7 @@ The Grafana Dashboard is now accessible via: `http://<Host IP Address>:3000` for
 	password - foobar (Password is stored in the `config.monitoring` env file)
 
 In order to check the status of the newly created stack:
-    
+
     $ docker stack ps prom
 
 View running services:
@@ -51,11 +51,11 @@ View running services:
     $ docker service ls
 
 View logs for a specific service
-  
+
     $ docker service logs prom_<service_name>
 
 ## Post Configuration
-Now we need to create the Prometheus Datasource in order to connect Grafana to Prometheus 
+Now we need to create the Prometheus Datasource in order to connect Grafana to Prometheus
 * Click the `Grafana` Menu at the top left corner (looks like a fireball)
 * Click `Data Sources`
 * Click the green button `Add Data Source`.
@@ -63,7 +63,7 @@ Now we need to create the Prometheus Datasource in order to connect Grafana to P
 <img src="https://github.com/vegasbrianc/prometheus/raw/version-2/images/Add_Data_Source.png" width="400" heighth="400">
 
 ## Alerting
-Alerting has been added to the stack with Slack integration. 2 Alerts have been added and are managed 
+Alerting has been added to the stack with Slack integration. 2 Alerts have been added and are managed
 
 Alerts              - `prometheus/alert.rules`
 Slack configuration - `alertmanager/config.yml`
@@ -111,17 +111,17 @@ Here are just a couple security considerations for this stack to help you get st
 * Enable SSL for Grafana with a Proxy such as [jwilder/nginx-proxy](https://hub.docker.com/r/jwilder/nginx-proxy/) or [Traefik](https://traefik.io/) with Let's Encrypt
 * Add user authentication via a Reverse Proxy [jwilder/nginx-proxy](https://hub.docker.com/r/jwilder/nginx-proxy/) or [Traefik](https://traefik.io/) for services cAdvisor, Prometheus, & Alerting as they don't support user authenticaiton
 * Terminate all services/containers via HTTPS/SSL/TLS
- 
+
 # Troubleshooting
 It appears some people have reported no data appearing in Grafana. If this is happening to you be sure to check the time range being queried within Grafana to ensure it is using Today's date with current time.
 
 ## Mac Users
 
-1. The node-exporter does not run the same as Mac and Linux. Node-Exporter is not designed to run on Mac and in fact cannot collect metrics from the Mac OS due to the differences between Mac and Linux OS's. I recommend you comment out the node-exporter section in the `docker-compose.yml` file and instead just use the cAdvisor. 
+1. The node-exporter does not run the same as Mac and Linux. Node-Exporter is not designed to run on Mac and in fact cannot collect metrics from the Mac OS due to the differences between Mac and Linux OS's. I recommend you comment out the node-exporter section in the `docker-compose.yml` file and instead just use the cAdvisor.
 
 2. If you find after you deploy your project that the prometheus and alertmanager services are in pending status due to "no suitable node" this is due to file system permissions. Be sure to Open Docker for Mac Preferences -> File Sharing Menu and add the following:
 
-![Docker for Mac File Sharing Settings](https://github.com/vegasbrianc/prometheus/blob/master/images/mac-filesystem.png)
+![Docker for Mac File Sharing Settings](https://github.com/vegasbrianc/prometheus/raw/master/images/mac-filesystem.png)
 
 # Interesting Projects that use this Repo
 Several projects utilize this Prometheus stack. Here's the list of projects:
@@ -131,4 +131,3 @@ Several projects utilize this Prometheus stack. Here's the list of projects:
 * [Traefik Reverse Proxy/Load Balancer Monitoring](https://github.com/vegasbrianc/docker-traefik-prometheus) - Monitor the popular Reverse Proxy/Load Balancer Traefik with Prometheus
 
 *Have an intersting Project which use this Repo? Submit yours to the list*
-


### PR DESCRIPTION
An image wasn't showing up on Visual Studio Code markdown preview, so I've changed it to the raw URL.
The editor also removed all trailing whitespace on README.md. 

See also: #93
