### PR TITLE
Fix docker-stack.yml indentaion issues

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,8 +49,8 @@ services:
       - monitor-net
     deploy:
       mode: global
-    restart_policy:
-        condition: on-failure
+      restart_policy:
+          condition: on-failure
 
   alertmanager:
     image: prom/alertmanager
@@ -83,8 +83,8 @@ services:
       - monitor-net
     deploy:
       mode: global
-    restart_policy:
-        condition: on-failure
+      restart_policy:
+          condition: on-failure
 
   grafana:
     image: grafana/grafana


### PR DESCRIPTION
Indentation is off for these properties so that
````
HOSTNAME=$(hostname) docker stack deploy -c docker-stack.yml prom
````
throws the following error
````
restart_policy Additional property restart_policy is not allowed
````