### PR TITLE
point to local prometheus configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Before we get started installing the Prometheus stack. Ensure you install the la
 # Installation & Configuration
 Clone the project locally to your Docker host.
 
-If you would like to change which targets should be monitored or make configuration changes edit the [/prometheus/prometheus.yml](https://github.com/vegasbrianc/prometheus/blob/version-2/prometheus/prometheus.yml) file. The targets section is where you define what should be monitored by Prometheus. The names defined in this file are actually sourced from the service name in the docker-compose file. If you wish to change names of the services you can add the "container_name" parameter in the `docker-compose.yml` file.
+If you would like to change which targets should be monitored or make configuration changes edit the [/prometheus/prometheus.yml](prometheus/prometheus.yml) file. The targets section is where you define what should be monitored by Prometheus. The names defined in this file are actually sourced from the service name in the docker-compose file. If you wish to change names of the services you can add the "container_name" parameter in the `docker-compose.yml` file.
 
 Once configurations are done let's start it up. From the /prometheus project directory run the following command:
 


### PR DESCRIPTION
Was passing through and discovered the link in the readme went to a 404. This should now point to the same version as the readme file (if you're on a branch for example) - not sure if that's better than pointing to a specific version though?