### PR TITLE
remove basic auth default values

### DIFF
--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -26,11 +26,11 @@ datasources:
   # <string> database name, if used
   database:
   # <bool> enable/disable basic auth
-  basicAuth: true
-  # <string> basic auth username
-  basicAuthUser: admin
-  # <string> basic auth password
-  basicAuthPassword: foobar
+  basicAuth: false
+  # <string> basic auth username, if used
+  basicAuthUser:
+  # <string> basic auth password, if used
+  basicAuthPassword:
   # <bool> enable/disable with credentials headers
   withCredentials:
   # <bool> mark as default datasource. Max one per org


### PR DESCRIPTION
These are not used anyway, since Prometheus is not configured to require Basic Auth.

Removing them clears up some confusion – why would you need to specify another user/password combination here? Particularly since it's not a native feature of Prometheus, and it's not used for Traefik either, I suggest removal.