### PR TITLE
Update grafana user id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
 
   grafana:
     image: grafana/grafana
-    user: "104"
+    user: "472"
     depends_on:
       - prometheus
     ports:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -99,7 +99,7 @@ services:
       - ./grafana/config.monitoring
     networks:
       - monitor-net
-    user: "104"
+    user: "472"
     deploy:
       placement:
         constraints:

--- a/docker-traefik-stack.yml
+++ b/docker-traefik-stack.yml
@@ -140,7 +140,7 @@ services:
       - ./grafana/config.monitoring
     networks:
       - monitor-net
-    user: "104"
+    user: "472"
     deploy:
       placement:
         constraints:


### PR DESCRIPTION
Fix the following error when updating from Grafana < 5.1: 

```
grafana_1                | t=2020-01-18T01:20:53+0000 lvl=eror msg="Server shutdown" logger=server reason="Service init failed: Migration failed err: Failed to roll back transaction due to error: %!s(<nil>): attempt to write a readonly database
```

For Grafana >= 5.1, uid is 472

Reference:
https://grafana.com/docs/grafana/latest/installation/docker/#user-id-changes