### PR TITLE
[chore]: Remove version property from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
     prometheus_data: {}
     grafana_data: {}


### PR DESCRIPTION
### 📦 Remove `version` property from `docker-compose.yml`

**Motivation:**
The `version` property in `docker-compose.yml` is now redundant in modern Docker Compose. The tool automatically uses the latest supported schema based on the [[Compose Specification](https://docs.docker.com/compose/compose-file/)](https://docs.docker.com/compose/compose-file/), making it unnecessary to explicitly declare a version.

**References:**

* [[Compose file versions and upgrading](https://docs.docker.com/compose/compose-file/legacy/)](https://docs.docker.com/compose/compose-file/legacy/)
* [[Compose Specification](https://docs.docker.com/compose/compose-file/)](https://docs.docker.com/compose/compose-file/)

**Benefits of this change:**

* Cleaner and more concise configuration
* Aligns with current best practices
* Avoids confusion over versioning
* Ensures better compatibility with future Compose CLI updates
